### PR TITLE
Resolves #1 Fixing problem with badly created pip

### DIFF
--- a/aws_sign/client/http.py
+++ b/aws_sign/client/http.py
@@ -1,3 +1,4 @@
+import six
 from tornado import gen
 from tornado.httpclient import AsyncHTTPClient, HTTPClient, HTTPRequest
 
@@ -27,7 +28,7 @@ def _get_logger(name='aws_sign.http'):
 
 def _lower(source, acc):
     """Set all dict keys to lowercase format."""
-    for k, v in source.iteritems():
+    for k, v in six.iteritems(source):
         acc[k.lower()] = _lower(v, {}) if type(v) is dict else v
     return acc
 
@@ -37,7 +38,7 @@ def _normalize(source):
 
 def _merge(source, overrides):
     """Deep merge of dicts."""
-    for ok, ov in overrides.iteritems():
+    for ok, ov in six.iteritems(overrides):
         if ok in source:
             if type(ov) == type(source[ok]):
                 if type(ov) == dict:
@@ -165,7 +166,7 @@ class HTTP(object):
     def _log_request(self, params):
         self.logger.debug('HTTPRequest')
         self.logger.debug('-----------')
-        for k, v in params.iteritems():
+        for k, v in six.iteritems(params):
             self.logger.debug('%s=%s' % (k.upper(), v))
     
     def sign(self, path, method, headers, qs, payload):
@@ -275,22 +276,22 @@ class AsyncHTTP(HTTP):
         raise gen.Return(resp)
 
 
-def _get_base_cls(async=False, sign=True):
-    impl = (AsyncHTTP,) if async else (SyncHTTP,)
+def _get_base_cls(asynch=False, sign=True):
+    impl = (AsyncHTTP,) if asynch else (SyncHTTP,)
     return (AuthMixin,) + impl if sign else impl 
 
 def get_instance(endpoint, constants_cls=DefaultServiceConstants, defaults=None, 
-                 async=True, sign=False, creds=None, logger=None):
+                 asynch=True, sign=False, creds=None, logger=None):
     """Create HTTPClient instance
     
-    An HTTPClient instance is dynamically assembled based on ``async`` and ``sign``
+    An HTTPClient instance is dynamically assembled based on ``asynch`` and ``sign``
     parameters.  A v4 signature authorizer is mixed in if signing is required.
 
     Parameters:
         endpoint: service endpoint
         constants_cls: ServiceConstants factory class
         defaults: keyword dict of default HTTPRequest parameters 
-        async: bool that determines if underlying client is async or sync
+        asynch: bool that determines if underlying client is asynchronous or synchronous
         sign: bool that determines if requests are signed
         creds: AWS Credentials
        
@@ -302,6 +303,6 @@ def get_instance(endpoint, constants_cls=DefaultServiceConstants, defaults=None,
     constants = constants_cls.from_url(endpoint)
 
     defaults = defaults if defaults else {}
-    base     = _get_base_cls(async, sign)
+    base     = _get_base_cls(asynch, sign)
     attrs    = {'auth': Authorization(constants, creds)} if sign else {}
     return type('HTTPClient', base, attrs)(constants, defaults=defaults, logger=logger)

--- a/aws_sign/test/service_constants_test.py
+++ b/aws_sign/test/service_constants_test.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from .. import ServiceConstants
 from .. import URLParseException
 from nose import tools
@@ -23,7 +25,7 @@ class TestServiceConstants(object):
     
     def test_defaults(self):
         consts = default_service_constants()
-        print consts
+        print(consts)
 
         tools.assert_equals(consts.scheme, 'https')
         tools.assert_equals(consts.host, HOST)
@@ -62,7 +64,7 @@ class TestServiceConstants(object):
                                            pattern='(https)://((\w+)\.(\w+))',
                                            **ALG_SIGN)
 
-        print consts        
+        print(consts)        
         tools.assert_equal(consts.host, host)
         tools.assert_equal(consts.service, service)
         tools.assert_equal(consts.region, region)

--- a/aws_sign/test/v4/sig_v4_service_constants_test.py
+++ b/aws_sign/test/v4/sig_v4_service_constants_test.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from aws_sign.v4 import Sigv4ServiceConstants
 
 from nose import tools
@@ -53,7 +55,7 @@ class TestServiceConstants(object):
     def test_header_aggregation(self):
         consts = DynamoDBServiceConstants.from_url('https://dynamodb.us-west-2.amazonaws.com')
         
-        print 'DYNAMODB HEADERS ', consts.headers
+        print('DYNAMODB HEADERS ', consts.headers)
         tools.assert_equals(consts.headers, {'host': 'dynamodb.us-west-2.amazonaws.com',
                                              'x-amz-date': None,
                                              'content-type': None,

--- a/aws_sign/v4/auth.py
+++ b/aws_sign/v4/auth.py
@@ -105,7 +105,7 @@ class Authorization(object):
         headers = headers if headers else {}
         credential_scope  = self.canonical_builder.credential_scope(datestamp)
         canonical_request = self.canonical_builder.canonical_request(amzdate, uri, method, qs, headers, payload)
-        signed_headers    = self.canonical_builder.signed_headers(headers.keys())
+        signed_headers    = self.canonical_builder.signed_headers(list(headers.keys()))
         string_to_sign    = self.string_to_sign(amzdate, credential_scope, canonical_request)
         signature         = self.signature(datestamp, string_to_sign)
 

--- a/aws_sign/v4/canonical.py
+++ b/aws_sign/v4/canonical.py
@@ -1,7 +1,6 @@
 import copy
-import urllib
-import base64
 import hashlib
+from six.moves.urllib import parse
 
 class ArgumentBuilder(object):
     """Constructs requiste arguments for Signature version 4 signing.
@@ -38,7 +37,7 @@ class ArgumentBuilder(object):
             return ''
         else:
             items = sorted(query_args.items(), key=lambda i: i[0])
-            return urllib.urlencode(items, True)
+            return parse.urlencode(items, True)
 
     def _merge_headers(self, headers):
         """Merges input headers with default headers 
@@ -64,7 +63,7 @@ class ArgumentBuilder(object):
         if not headers:
             headers = []
         return ';'.join(sorted([name.lower() for name in 
-                                set(self.constants.headers.keys() + headers)]))
+                                set(list(self.constants.headers.keys()) + headers)]))
 
     def canonical_headers(self, amzdate, headers=None):
         """Constructs canonical headers
@@ -98,7 +97,7 @@ class ArgumentBuilder(object):
              uri, 
              qs, 
              self.canonical_headers(amzdate, headers), 
-             self.signed_headers(headers.keys() if headers else None),
+             self.signed_headers(list(headers.keys()) if headers else None),
              ArgumentBuilder.payload_hash(payload))
 
     def credential_scope(self, datestamp):

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
-0.4.6
-* bumping version to allow creation of a new, clean pip
+0.5.0
+* Python 3 compatibility changes
+* breaking change is changing `async` named parameter to `asynch`
 
 0.4.5
 * http module defers logging configuration to application.

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+0.4.6
+* bumping version to allow creation of a new, clean pip
+
 0.4.5
 * http module defers logging configuration to application.
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = 'aws_sign',
-    version = '0.4.5',
+    version = '0.4.6',
     author = 'Navil Charles',
     author_email = 'navil.charles@gmail.com',
     description = 'AWS Signing Tools',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = 'aws_sign',
-    version = '0.4.6',
+    version = '0.5.0',
     author = 'Navil Charles',
     author_email = 'navil.charles@gmail.com',
     description = 'AWS Signing Tools',
@@ -27,5 +27,6 @@ setup(
         'nose'
         ],
     install_requires = [
+        'six >= 1.7.0',
         'tornado >= 4.0'
         ])


### PR DESCRIPTION
pip for 0.4.5 was created by a dummy that managed to include some of his code in the pip, and it happens to throw nosetests into DEBUG mode when aws-sign.client is imported. Oddly, the test code looks a lot like mine...