### PR TITLE
Python 2/3 compatibility changes

### DIFF
--- a/aws_sign/client/http.py
+++ b/aws_sign/client/http.py
@@ -1,3 +1,4 @@
+import six
 from tornado import gen
 from tornado.httpclient import AsyncHTTPClient, HTTPClient, HTTPRequest
 
@@ -27,7 +28,7 @@ def _get_logger(name='aws_sign.http'):
 
 def _lower(source, acc):
     """Set all dict keys to lowercase format."""
-    for k, v in source.iteritems():
+    for k, v in six.iteritems(source):
         acc[k.lower()] = _lower(v, {}) if type(v) is dict else v
     return acc
 
@@ -37,7 +38,7 @@ def _normalize(source):
 
 def _merge(source, overrides):
     """Deep merge of dicts."""
-    for ok, ov in overrides.iteritems():
+    for ok, ov in six.iteritems(overrides):
         if ok in source:
             if type(ov) == type(source[ok]):
                 if type(ov) == dict:
@@ -165,7 +166,7 @@ class HTTP(object):
     def _log_request(self, params):
         self.logger.debug('HTTPRequest')
         self.logger.debug('-----------')
-        for k, v in params.iteritems():
+        for k, v in six.iteritems(params):
             self.logger.debug('%s=%s' % (k.upper(), v))
     
     def sign(self, path, method, headers, qs, payload):
@@ -275,22 +276,22 @@ class AsyncHTTP(HTTP):
         raise gen.Return(resp)
 
 
-def _get_base_cls(async=False, sign=True):
-    impl = (AsyncHTTP,) if async else (SyncHTTP,)
+def _get_base_cls(asynch=False, sign=True):
+    impl = (AsyncHTTP,) if asynch else (SyncHTTP,)
     return (AuthMixin,) + impl if sign else impl 
 
 def get_instance(endpoint, constants_cls=DefaultServiceConstants, defaults=None, 
-                 async=True, sign=False, creds=None, logger=None):
+                 asynch=True, sign=False, creds=None, logger=None):
     """Create HTTPClient instance
     
-    An HTTPClient instance is dynamically assembled based on ``async`` and ``sign``
+    An HTTPClient instance is dynamically assembled based on ``asynch`` and ``sign``
     parameters.  A v4 signature authorizer is mixed in if signing is required.
 
     Parameters:
         endpoint: service endpoint
         constants_cls: ServiceConstants factory class
         defaults: keyword dict of default HTTPRequest parameters 
-        async: bool that determines if underlying client is async or sync
+        asynch: bool that determines if underlying client is asynchronous or synchronous
         sign: bool that determines if requests are signed
         creds: AWS Credentials
        
@@ -302,6 +303,6 @@ def get_instance(endpoint, constants_cls=DefaultServiceConstants, defaults=None,
     constants = constants_cls.from_url(endpoint)
 
     defaults = defaults if defaults else {}
-    base     = _get_base_cls(async, sign)
+    base     = _get_base_cls(asynch, sign)
     attrs    = {'auth': Authorization(constants, creds)} if sign else {}
     return type('HTTPClient', base, attrs)(constants, defaults=defaults, logger=logger)

--- a/aws_sign/test/service_constants_test.py
+++ b/aws_sign/test/service_constants_test.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from .. import ServiceConstants
 from .. import URLParseException
 from nose import tools
@@ -23,7 +25,7 @@ class TestServiceConstants(object):
     
     def test_defaults(self):
         consts = default_service_constants()
-        print consts
+        print(consts)
 
         tools.assert_equals(consts.scheme, 'https')
         tools.assert_equals(consts.host, HOST)
@@ -62,7 +64,7 @@ class TestServiceConstants(object):
                                            pattern='(https)://((\w+)\.(\w+))',
                                            **ALG_SIGN)
 
-        print consts        
+        print(consts)        
         tools.assert_equal(consts.host, host)
         tools.assert_equal(consts.service, service)
         tools.assert_equal(consts.region, region)

--- a/aws_sign/test/v4/authorization_tests.py
+++ b/aws_sign/test/v4/authorization_tests.py
@@ -40,7 +40,7 @@ class TestAuthorization(object):
         creds  = get_creds()
         
         sign = auth.Authorization.sign('foo-key', 'bar-msg')
-        tools.assert_equal(sign, "2\xce?\xb4\x12`\xd9\xb2\xae\xe2\xe9\x14\x0c\x837\xca\x13\r\x95\xd7\x93r}\xa1D\xf4\xa6\xb1\xc0Y\xd8\xc4")
+        tools.assert_equal(sign, b"2\xce?\xb4\x12`\xd9\xb2\xae\xe2\xe9\x14\x0c\x837\xca\x13\r\x95\xd7\x93r}\xa1D\xf4\xa6\xb1\xc0Y\xd8\xc4")
 
 
     def test_signature_key(self):
@@ -49,7 +49,7 @@ class TestAuthorization(object):
         awth   = get_auth(consts, creds)
 
         key = awth.signature_key('20160101')
-        tools.assert_equal(key, "\xbbX\x80\x8f?\xa6\xc3\x10\xc2ZS\x10\xc5\xd9\xf0\xd7!\x88\xe9N\x9a.S9\xc3\xde\xd6'\xba-e\x08")
+        tools.assert_equal(key, b"\xbbX\x80\x8f?\xa6\xc3\x10\xc2ZS\x10\xc5\xd9\xf0\xd7!\x88\xe9N\x9a.S9\xc3\xde\xd6'\xba-e\x08")
 
     def test_signature(self):
         consts = get_constants()

--- a/aws_sign/test/v4/sig_v4_service_constants_test.py
+++ b/aws_sign/test/v4/sig_v4_service_constants_test.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from aws_sign.v4 import Sigv4ServiceConstants
 
 from nose import tools
@@ -53,7 +55,7 @@ class TestServiceConstants(object):
     def test_header_aggregation(self):
         consts = DynamoDBServiceConstants.from_url('https://dynamodb.us-west-2.amazonaws.com')
         
-        print 'DYNAMODB HEADERS ', consts.headers
+        print('DYNAMODB HEADERS ', consts.headers)
         tools.assert_equals(consts.headers, {'host': 'dynamodb.us-west-2.amazonaws.com',
                                              'x-amz-date': None,
                                              'content-type': None,

--- a/aws_sign/test/v4/util_tests.py
+++ b/aws_sign/test/v4/util_tests.py
@@ -1,0 +1,27 @@
+from nose import tools
+
+from aws_sign.v4.util import safe_encode
+
+
+class TestSafeEncode(object):
+
+    def test_unicode(self):
+        before = u'howdy'
+        after = safe_encode(before)
+        expected = b'howdy'
+        tools.assert_equal(after, expected)
+        tools.assert_equal(type(after), type(expected))
+
+    def test_bytes(self):
+        before = b'howdy'
+        after = safe_encode(before)
+        expected = b'howdy'
+        tools.assert_equal(after, expected)
+        tools.assert_equal(type(after), type(expected))
+
+    def test_natural(self):
+        before = 'howdy'
+        after = safe_encode(before)
+        expected = b'howdy'
+        tools.assert_equal(after, expected)
+        tools.assert_equal(type(after), type(expected))

--- a/aws_sign/v4/auth.py
+++ b/aws_sign/v4/auth.py
@@ -2,7 +2,7 @@ import hmac
 import hashlib
 
 from . import canonical
-
+from .util import safe_encode
 
 class Authorization(object):
     """Class for signing AWS HTTP requests adhering to Signature Version 4 specification
@@ -35,7 +35,7 @@ class Authorization(object):
             msg: hash message
             
         Returns message authentication signature"""
-        return hmac.new(key, msg.encode('utf-8'), hashlib.sha256).digest()
+        return hmac.new(safe_encode(key), safe_encode(msg), hashlib.sha256).digest()
 
     def _header(self, credential_scope, signed_headers, signature):
         """Creates HTTP header
@@ -63,17 +63,17 @@ class Authorization(object):
             (self.constants.algorithm, 
              amzdate, 
              credential_scope, 
-             hashlib.sha256(canonical_request).hexdigest())
+             hashlib.sha256(safe_encode(canonical_request)).hexdigest())
 
     def signature(self, datestamp, string_to_sign):
-        """Creates signture of HTTP request
+        """Creates signature of HTTP request
         
         Parameters:
             datestamp: '%Y%m%d' stamp
             string_to_string: hash input string
             
         Returns string signature"""
-        return hmac.new(self.signature_key(datestamp), (string_to_sign).encode('utf-8'), hashlib.sha256).hexdigest()
+        return hmac.new(self.signature_key(datestamp), safe_encode(string_to_sign), hashlib.sha256).hexdigest()
 
     def signature_key(self, date_stamp):
         """Creates signing key
@@ -82,7 +82,7 @@ class Authorization(object):
             date_stamp: '%Y%m%d' stamp
 
         Returns signing key string"""
-        date    = Authorization.sign(('AWS4' + self.creds.secret_key).encode('utf-8'), date_stamp)
+        date    = Authorization.sign(safe_encode('AWS4' + self.creds.secret_key), date_stamp)
         region  = Authorization.sign(date, self.constants.region)
         service = Authorization.sign(region, self.constants.service)
         signing = Authorization.sign(service, self.constants.signing)

--- a/aws_sign/v4/auth.py
+++ b/aws_sign/v4/auth.py
@@ -105,7 +105,7 @@ class Authorization(object):
         headers = headers if headers else {}
         credential_scope  = self.canonical_builder.credential_scope(datestamp)
         canonical_request = self.canonical_builder.canonical_request(amzdate, uri, method, qs, headers, payload)
-        signed_headers    = self.canonical_builder.signed_headers(headers.keys())
+        signed_headers    = self.canonical_builder.signed_headers(list(headers.keys()))
         string_to_sign    = self.string_to_sign(amzdate, credential_scope, canonical_request)
         signature         = self.signature(datestamp, string_to_sign)
 

--- a/aws_sign/v4/canonical.py
+++ b/aws_sign/v4/canonical.py
@@ -1,7 +1,6 @@
 import copy
-import urllib
-import base64
 import hashlib
+from six.moves.urllib import parse
 
 class ArgumentBuilder(object):
     """Constructs requiste arguments for Signature version 4 signing.
@@ -38,7 +37,7 @@ class ArgumentBuilder(object):
             return ''
         else:
             items = sorted(query_args.items(), key=lambda i: i[0])
-            return urllib.urlencode(items, True)
+            return parse.urlencode(items, True)
 
     def _merge_headers(self, headers):
         """Merges input headers with default headers 
@@ -64,7 +63,7 @@ class ArgumentBuilder(object):
         if not headers:
             headers = []
         return ';'.join(sorted([name.lower() for name in 
-                                set(self.constants.headers.keys() + headers)]))
+                                set(list(self.constants.headers.keys()) + headers)]))
 
     def canonical_headers(self, amzdate, headers=None):
         """Constructs canonical headers
@@ -98,7 +97,7 @@ class ArgumentBuilder(object):
              uri, 
              qs, 
              self.canonical_headers(amzdate, headers), 
-             self.signed_headers(headers.keys() if headers else None),
+             self.signed_headers(list(headers.keys()) if headers else None),
              ArgumentBuilder.payload_hash(payload))
 
     def credential_scope(self, datestamp):

--- a/aws_sign/v4/canonical.py
+++ b/aws_sign/v4/canonical.py
@@ -2,6 +2,8 @@ import copy
 import hashlib
 from six.moves.urllib import parse
 
+from .util import safe_encode
+
 class ArgumentBuilder(object):
     """Constructs requiste arguments for Signature version 4 signing.
 
@@ -98,7 +100,7 @@ class ArgumentBuilder(object):
              qs, 
              self.canonical_headers(amzdate, headers), 
              self.signed_headers(list(headers.keys()) if headers else None),
-             ArgumentBuilder.payload_hash(payload))
+             ArgumentBuilder.payload_hash(safe_encode(payload)))
 
     def credential_scope(self, datestamp):
         """Constructs signing credential scope 

--- a/aws_sign/v4/util.py
+++ b/aws_sign/v4/util.py
@@ -1,0 +1,17 @@
+"""Utility functions for aws-sign"""
+
+def safe_encode(s):
+    """
+    Attempt to encode a string with UTF-8, regarding some exceptions as indicating that it is already in that state.
+
+    The `hashlib` functions tend to require parameters to be byte strings, rather than Unicode, but it is tricky
+    to handle all the possibilities in both Python 2 and 3 environments.  This tries to encode a string as UTF-8.
+    It catches tell-tale exceptions indicating that the passed in string is already a byte string.
+
+    :param s: any sort of string
+    :return: a byte string ('str' in Python 2, 'bytes' in Python 3)
+    """
+    try:
+        return s.encode('utf-8')
+    except (AttributeError, UnicodeDecodeError):
+        return s

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
-0.4.6
-* bumping version to allow creation of a new, clean pip
+0.5.0
+* Python 3 compatibility changes
+* breaking change is changing `async` named parameter to `asynch`
 
 0.4.5
 * http module defers logging configuration to application.

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+0.4.6
+* bumping version to allow creation of a new, clean pip
+
 0.4.5
 * http module defers logging configuration to application.
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = 'aws_sign',
-    version = '0.4.5',
+    version = '0.4.6',
     author = 'Navil Charles',
     author_email = 'navil.charles@gmail.com',
     description = 'AWS Signing Tools',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = 'aws_sign',
-    version = '0.4.6',
+    version = '0.5.0',
     author = 'Navil Charles',
     author_email = 'navil.charles@gmail.com',
     description = 'AWS Signing Tools',
@@ -27,5 +27,6 @@ setup(
         'nose'
         ],
     install_requires = [
+        'six >= 1.7.0',
         'tornado >= 4.0'
         ])


### PR DESCRIPTION
- added six dependency
- changed `async` to `asynch` in a few places (new reserved word)
- the occasional list() around things that would be generators
- a bit of string hell brought on by the low-level signing functions wanting byte strings only